### PR TITLE
RightAlignedText compenent

### DIFF
--- a/x-pack/plugins/maps/public/classes/styles/vector/components/legend/right_aligned_text.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/vector/components/legend/right_aligned_text.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Component, CSSProperties, RefObject } from 'react';
+
+interface Props {
+  setWidth: (width: number) => void;
+  style: CSSProperties;
+  value: string | number;
+  x: number;
+  y: number;
+}
+
+export class RightAlignedText extends Component<Props> {
+  private _textRef: RefObject<SVGTextElement> = React.createRef<SVGTextElement>();
+  
+  componentDidMount() {
+    this._setWidth();
+  }
+
+  componentDidUpdate() {
+    this._setWidth();
+  }
+
+  _setWidth() {
+    if (this._textRef.current) {
+      this.props.setWidth(this._textRef.current.getBBox().width);
+    }
+  }
+
+  render() {
+    return (
+      <text
+        ref={this._textRef}
+        style={this.props.style}
+        textAnchor="end"
+        x={this.props.x}
+        y={this.props.y}
+      >
+        {this.props.value}
+      </text>
+    );
+  }
+}

--- a/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property/__snapshots__/dynamic_size_property.test.tsx.snap
+++ b/x-pack/plugins/maps/public/classes/styles/vector/properties/dynamic_size_property/__snapshots__/dynamic_size_property.test.tsx.snap
@@ -52,19 +52,18 @@ exports[`renderLegendDetailRow Should render icon size scale 1`] = `
         y1={26}
         y2={26}
       />
-      <text
+      <RightAlignedText
+        setWidth={[Function]}
         style={
           Object {
             "fill": "#343741",
             "fontSize": 10,
           }
         }
-        textAnchor="end"
-        x={-975.25}
+        value="0_format"
+        x={29.75}
         y={31}
-      >
-        0_format
-      </text>
+      />
       <circle
         cx={11}
         cy={26}
@@ -92,19 +91,18 @@ exports[`renderLegendDetailRow Should render icon size scale 1`] = `
         y1={16}
         y2={16}
       />
-      <text
+      <RightAlignedText
+        setWidth={[Function]}
         style={
           Object {
             "fill": "#343741",
             "fontSize": 10,
           }
         }
-        textAnchor="end"
-        x={-975.25}
+        value="25_format"
+        x={29.75}
         y={21}
-      >
-        25_format
-      </text>
+      />
       <circle
         cx={11}
         cy={21}
@@ -132,19 +130,18 @@ exports[`renderLegendDetailRow Should render icon size scale 1`] = `
         y1={6}
         y2={6}
       />
-      <text
+      <RightAlignedText
+        setWidth={[Function]}
         style={
           Object {
             "fill": "#343741",
             "fontSize": 10,
           }
         }
-        textAnchor="end"
-        x={-975.25}
+        value="100_format"
+        x={29.75}
         y={11}
-      >
-        100_format
-      </text>
+      />
       <circle
         cx={11}
         cy={16}


### PR DESCRIPTION
One more fix. The original ref implementation I provided only worked because props keep changing. Otherwise, componentDidUpdate would not fire and reset maxLabelSize. This new implementation is more robust and will work regardless of prop updates.